### PR TITLE
Notify User if we cannot add a product to the cart

### DIFF
--- a/shopify-client/src/store/index.js
+++ b/shopify-client/src/store/index.js
@@ -9,12 +9,15 @@ export default new Vuex.Store({
     cart: {},
   },
   mutations: {
-    addProduct: (state, productId) => {
-
-      state.cart = Object.assign({}, state.cart, {
-        [productId]: state.cart[productId] + 1 || 1,
-      });
-      Cookies.set('cart', state.cart);
+    addProduct: (state, product) => {
+      if (state.cart[product.id] === product.quantity) {
+        alert("Cannot Add Product to Cart - Insufficient Stock");
+      } else {
+        state.cart = Object.assign({}, state.cart, {
+          [product.id]: state.cart[product.id] + 1 || 1,
+        });
+        Cookies.set('cart', state.cart);
+      }
     },
     removeProduct: (state, productId) => {
       const cartClone = Object.assign({}, state.cart);

--- a/shopify-client/src/views/ShopDetails.vue
+++ b/shopify-client/src/views/ShopDetails.vue
@@ -81,7 +81,7 @@
                     class="card-button"
                     >Details</b-button
                   >
-                  <b-button href="#" variant="primary" class="card-button" @click="addProductToCart(product.id)"
+                  <b-button href="#" variant="primary" class="card-button" @click="addProductToCart(product)"
                     >Add to Cart</b-button
                   >
                 </b-card>
@@ -120,9 +120,8 @@ export default {
       // Redirect to Create Page Page
       this.$router.push(`/app/shops/${this.id}/products/create`);
     },
-    addProductToCart(id) {
-
-      this.$store.commit('addProduct', id);
+    addProductToCart(product) {
+      this.$store.commit('addProduct', product);
     }
   },
   props: ["id"],


### PR DESCRIPTION
When we attempt to add a product to the cart, we only do so if the product is in sufficient quantities to be added to the cart.

Prior to this change, the user was given no indication what occured when there weren't enough of the product to add the cart.
This change shows the user an alert saying: "Cannot Add Product to Cart - Insufficient Stock" in that case.

Closes #107 