### PR TITLE
fix: Make checkout page has same quantity as shopping cart

### DIFF
--- a/shopify-client/src/views/Checkout.vue
+++ b/shopify-client/src/views/Checkout.vue
@@ -27,7 +27,7 @@
           <p>{{ product.name }}</p>
         </b-col>
         <b-col>
-          <p>{{ product.quantity }}</p>
+          <p>{{ cart[product.id] }}</p>
         </b-col>
         <b-col>
           <p>${{ product.quantity * product.price }}</p>
@@ -132,7 +132,7 @@ export default {
           body: JSON.stringify({
             checkouts: this.products.map((p) => ({
               id: p.id,
-              quantity: p.quantity,
+              quantity: this.cart[p.id],
             })),
           }),
         }).then((response) => {


### PR DESCRIPTION
Make the quantities listed in the Checkout page to have the same quantities that was chosen by the user in the shopping cart.

Closes #97 