### PR TITLE
fix: removed login and signup page

### DIFF
--- a/shopify-client/src/components/Header.vue
+++ b/shopify-client/src/components/Header.vue
@@ -29,8 +29,6 @@
               <!-- Right aligned nav items -->
               <b-navbar-nav class="ml-auto">
                 <b-nav-item to="/app/about">About</b-nav-item>
-                <b-nav-item to="/app/login">Login</b-nav-item>
-                <b-nav-item to="/app/signup">Sign Up</b-nav-item>
               </b-navbar-nav>
             </b-collapse>
           </b-col>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35379392/113934213-74449280-97c3-11eb-93e7-eee7144ae264.png)
Due to the scraping of auth, removing old header components.

Closes #110 