### PR TITLE
feat: Add ability to delete product

### DIFF
--- a/shopify-client/src/views/ProductCreate.vue
+++ b/shopify-client/src/views/ProductCreate.vue
@@ -63,7 +63,7 @@ export default {
 }
 
 .center {
-  margin-left: 500px;
-  margin-right: 500px;
+  margin-left: 10%;
+  margin-right: 10%;
 }
 </style>

--- a/shopify-client/src/views/ProductDetails.vue
+++ b/shopify-client/src/views/ProductDetails.vue
@@ -34,8 +34,13 @@
                 <b-button
                   v-bind:to="'/app/shops/' + shopId + '/products/update/' + id"
                   variant="primary"
-                  >Update</b-button
-                >
+                >Update</b-button>
+              </b-col>
+              <b-col sm="12">
+                <b-button
+                  variant="danger"
+                  v-on:click = "deleteProduct()"
+                >Delete</b-button>
               </b-col>
             </b-row>
           </b-col>
@@ -73,6 +78,17 @@ export default {
   },
   methods: {
     shopDetails() {
+      this.$router.push(`/app/shops/${this.shopId}`);
+    },
+
+    deleteProduct() {
+      this.$store.commit('removeProduct', this.id);
+
+      fetch(`/api/products/delete/${this.id}`, {
+        method: "DELETE"
+      });
+
+      // Navigate to the shop detail page
       this.$router.push(`/app/shops/${this.shopId}`);
     },
   },

--- a/src/main/java/com/shopify/minishopify/controllers/ProductController.java
+++ b/src/main/java/com/shopify/minishopify/controllers/ProductController.java
@@ -94,11 +94,11 @@ public class ProductController {
 
     @DeleteMapping("/products/delete/{id}")
     public Product deleteProductById(@PathVariable int id) {
-        Product product = null;
         Optional<Product> optional = productRepository.findById(id);
 
         if(optional.isPresent()) {
-            product = optional.get();
+            Product product = optional.get();
+            product.getShop().removeProduct(product);
             productRepository.deleteById(product.getId());
 
             return product;

--- a/src/main/java/com/shopify/minishopify/model/Shop.java
+++ b/src/main/java/com/shopify/minishopify/model/Shop.java
@@ -141,6 +141,11 @@ public class Shop {
         products.add(product);
     }
 
+    public void removeProduct(Product product) {
+        product.setShop(null);
+        products.remove(product);
+    }
+
     public void addTag(Tag tag) {
         tags.add(tag);
     }

--- a/src/test/java/com/shopify/minishopify/controllers/ProductControllerTest.java
+++ b/src/test/java/com/shopify/minishopify/controllers/ProductControllerTest.java
@@ -19,7 +19,10 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
@@ -135,5 +138,17 @@ public class ProductControllerTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value(product.getName()));
+    }
+
+    @Test
+    public void whenDeleteNewProduct_thenRemoveFromShopAndDelete() throws Exception {
+        when(productRepository.findById(product.getId())).thenReturn(Optional.of(product));
+
+        mvc.perform(delete("/api/products/delete/" + product.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value(product.getName()));
+        assertFalse(shop.getProducts().contains(product));
+        assertNotEquals(shop, product.getShop());
+        verify(productRepository).deleteById(product.getId());
     }
 }


### PR DESCRIPTION
This feature allows you to delete a product. This can be done from the product details page and results in the user being redirected to the store page.

Misc changes are to make the product creation screen able to handle small viewports by using relative % based margins.

Closes #122 